### PR TITLE
Make use of CMake Tools in VS Code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,14 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"ms-vscode.cpptools",
+		"ms-vscode.cmake-tools",
+		"webfreak.debug"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+	]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,6 +24,14 @@
             "target": "./build/apps/qt/coronanApp",
             "cwd": "${workspaceRoot}",
             "valuesFormatting": "parseText"
+        },
+        {
+            "name": "CMake Tools target (GDB)",
+            "type": "gdb",
+            "request": "launch",
+            "target": "${command:cmake.launchTargetPath}",
+            "cwd": "${workspaceRoot}",
+            "valuesFormatting": "parseText"
         }
     ]
 }


### PR DESCRIPTION
CMake Tools discover the targets. Selecting the corresponding entry for starting the debugger lets the CMake Tools take care of which target to rebuild prior to starting the debugging